### PR TITLE
Rename DriveDirection.None to Blocked

### DIFF
--- a/.idea/.idea.Point2Point/.idea/.gitignore
+++ b/.idea/.idea.Point2Point/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/.idea.Point2Point.iml
+/modules.xml
+/projectSettingsUpdater.xml
+/contentModel.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.Point2Point/.idea/.name
+++ b/.idea/.idea.Point2Point/.idea/.name
@@ -1,0 +1,1 @@
+Point2Point

--- a/.idea/.idea.Point2Point/.idea/encodings.xml
+++ b/.idea/.idea.Point2Point/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.Point2Point/.idea/indexLayout.xml
+++ b/.idea/.idea.Point2Point/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.Point2Point/.idea/vcs.xml
+++ b/.idea/.idea.Point2Point/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Point2Point/DriveDirection.cs
+++ b/Point2Point/DriveDirection.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Point2Point
+﻿namespace Point2Point
 {
     public enum DriveDirection
     {
         Forward,
         Backward,
         Both,
-        None
+        Blocked
     }
 }

--- a/Point2Point/Point2Point.nuspec
+++ b/Point2Point/Point2Point.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Point2PointMotion</id>
-        <version>1.0.3</version>
+        <version>1.1.0</version>
         <description>Maths for Point-To-Point motion</description>
         <authors>Max Dhom</authors>
         <dependencies>


### PR DESCRIPTION
When generating API-Clients for Python, an enum value of "None" is a problem, because "None" is a built-in type within python.